### PR TITLE
Addresses associations with mint tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ buf format --write
 2. lint proto files
 
 ```bash
-buf lint && buf buil
+buf lint && buf build
 ```
 
 3. generate swift/kotlin files

--- a/Sources/swift/vultisig/keysign/v1/blockchain_specific.pb.swift
+++ b/Sources/swift/vultisig/keysign/v1/blockchain_specific.pb.swift
@@ -107,6 +107,10 @@ public struct VSSolanaSpecific {
 
   public var priorityFee: String = String()
 
+  public var fromTokenAssociatedAddress: String = String()
+
+  public var toTokenAssociatedAddress: String = String()
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -397,6 +401,8 @@ extension VSSolanaSpecific: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "recent_block_hash"),
     2: .standard(proto: "priority_fee"),
+    3: .standard(proto: "from_token_associated_address"),
+    4: .standard(proto: "to_token_associated_address"),
   ]
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -407,6 +413,8 @@ extension VSSolanaSpecific: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularStringField(value: &self.recentBlockHash) }()
       case 2: try { try decoder.decodeSingularStringField(value: &self.priorityFee) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.fromTokenAssociatedAddress) }()
+      case 4: try { try decoder.decodeSingularStringField(value: &self.toTokenAssociatedAddress) }()
       default: break
       }
     }
@@ -419,12 +427,20 @@ extension VSSolanaSpecific: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
     if !self.priorityFee.isEmpty {
       try visitor.visitSingularStringField(value: self.priorityFee, fieldNumber: 2)
     }
+    if !self.fromTokenAssociatedAddress.isEmpty {
+      try visitor.visitSingularStringField(value: self.fromTokenAssociatedAddress, fieldNumber: 3)
+    }
+    if !self.toTokenAssociatedAddress.isEmpty {
+      try visitor.visitSingularStringField(value: self.toTokenAssociatedAddress, fieldNumber: 4)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: VSSolanaSpecific, rhs: VSSolanaSpecific) -> Bool {
     if lhs.recentBlockHash != rhs.recentBlockHash {return false}
     if lhs.priorityFee != rhs.priorityFee {return false}
+    if lhs.fromTokenAssociatedAddress != rhs.fromTokenAssociatedAddress {return false}
+    if lhs.toTokenAssociatedAddress != rhs.toTokenAssociatedAddress {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Sources/swift/vultisig/keysign/v1/blockchain_specific.pb.swift
+++ b/Sources/swift/vultisig/keysign/v1/blockchain_specific.pb.swift
@@ -107,13 +107,30 @@ public struct VSSolanaSpecific {
 
   public var priorityFee: String = String()
 
-  public var fromTokenAssociatedAddress: String = String()
+  public var fromTokenAssociatedAddress: String {
+    get {return _fromTokenAssociatedAddress ?? String()}
+    set {_fromTokenAssociatedAddress = newValue}
+  }
+  /// Returns true if `fromTokenAssociatedAddress` has been explicitly set.
+  public var hasFromTokenAssociatedAddress: Bool {return self._fromTokenAssociatedAddress != nil}
+  /// Clears the value of `fromTokenAssociatedAddress`. Subsequent reads from it will return its default value.
+  public mutating func clearFromTokenAssociatedAddress() {self._fromTokenAssociatedAddress = nil}
 
-  public var toTokenAssociatedAddress: String = String()
+  public var toTokenAssociatedAddress: String {
+    get {return _toTokenAssociatedAddress ?? String()}
+    set {_toTokenAssociatedAddress = newValue}
+  }
+  /// Returns true if `toTokenAssociatedAddress` has been explicitly set.
+  public var hasToTokenAssociatedAddress: Bool {return self._toTokenAssociatedAddress != nil}
+  /// Clears the value of `toTokenAssociatedAddress`. Subsequent reads from it will return its default value.
+  public mutating func clearToTokenAssociatedAddress() {self._toTokenAssociatedAddress = nil}
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
+
+  fileprivate var _fromTokenAssociatedAddress: String? = nil
+  fileprivate var _toTokenAssociatedAddress: String? = nil
 }
 
 public struct VSPolkadotSpecific {
@@ -413,34 +430,38 @@ extension VSSolanaSpecific: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularStringField(value: &self.recentBlockHash) }()
       case 2: try { try decoder.decodeSingularStringField(value: &self.priorityFee) }()
-      case 3: try { try decoder.decodeSingularStringField(value: &self.fromTokenAssociatedAddress) }()
-      case 4: try { try decoder.decodeSingularStringField(value: &self.toTokenAssociatedAddress) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self._fromTokenAssociatedAddress) }()
+      case 4: try { try decoder.decodeSingularStringField(value: &self._toTokenAssociatedAddress) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if !self.recentBlockHash.isEmpty {
       try visitor.visitSingularStringField(value: self.recentBlockHash, fieldNumber: 1)
     }
     if !self.priorityFee.isEmpty {
       try visitor.visitSingularStringField(value: self.priorityFee, fieldNumber: 2)
     }
-    if !self.fromTokenAssociatedAddress.isEmpty {
-      try visitor.visitSingularStringField(value: self.fromTokenAssociatedAddress, fieldNumber: 3)
-    }
-    if !self.toTokenAssociatedAddress.isEmpty {
-      try visitor.visitSingularStringField(value: self.toTokenAssociatedAddress, fieldNumber: 4)
-    }
+    try { if let v = self._fromTokenAssociatedAddress {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 3)
+    } }()
+    try { if let v = self._toTokenAssociatedAddress {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 4)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: VSSolanaSpecific, rhs: VSSolanaSpecific) -> Bool {
     if lhs.recentBlockHash != rhs.recentBlockHash {return false}
     if lhs.priorityFee != rhs.priorityFee {return false}
-    if lhs.fromTokenAssociatedAddress != rhs.fromTokenAssociatedAddress {return false}
-    if lhs.toTokenAssociatedAddress != rhs.toTokenAssociatedAddress {return false}
+    if lhs._fromTokenAssociatedAddress != rhs._fromTokenAssociatedAddress {return false}
+    if lhs._toTokenAssociatedAddress != rhs._toTokenAssociatedAddress {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/kotlin/src/main/kotlin/vultisig/keysign/v1/SolanaSpecificKt.kt
+++ b/kotlin/src/main/kotlin/vultisig/keysign/v1/SolanaSpecificKt.kt
@@ -63,7 +63,7 @@ public object SolanaSpecificKt {
     }
 
     /**
-     * `string from_token_associated_address = 3 [json_name = "fromTokenAssociatedAddress"];`
+     * `optional string from_token_associated_address = 3 [json_name = "fromTokenAssociatedAddress"];`
      */
     public var fromTokenAssociatedAddress: kotlin.String
       @JvmName("getFromTokenAssociatedAddress")
@@ -73,14 +73,21 @@ public object SolanaSpecificKt {
         _builder.setFromTokenAssociatedAddress(value)
       }
     /**
-     * `string from_token_associated_address = 3 [json_name = "fromTokenAssociatedAddress"];`
+     * `optional string from_token_associated_address = 3 [json_name = "fromTokenAssociatedAddress"];`
      */
     public fun clearFromTokenAssociatedAddress() {
       _builder.clearFromTokenAssociatedAddress()
     }
+    /**
+     * `optional string from_token_associated_address = 3 [json_name = "fromTokenAssociatedAddress"];`
+     * @return Whether the fromTokenAssociatedAddress field is set.
+     */
+    public fun hasFromTokenAssociatedAddress(): kotlin.Boolean {
+      return _builder.hasFromTokenAssociatedAddress()
+    }
 
     /**
-     * `string to_token_associated_address = 4 [json_name = "toTokenAssociatedAddress"];`
+     * `optional string to_token_associated_address = 4 [json_name = "toTokenAssociatedAddress"];`
      */
     public var toTokenAssociatedAddress: kotlin.String
       @JvmName("getToTokenAssociatedAddress")
@@ -90,10 +97,17 @@ public object SolanaSpecificKt {
         _builder.setToTokenAssociatedAddress(value)
       }
     /**
-     * `string to_token_associated_address = 4 [json_name = "toTokenAssociatedAddress"];`
+     * `optional string to_token_associated_address = 4 [json_name = "toTokenAssociatedAddress"];`
      */
     public fun clearToTokenAssociatedAddress() {
       _builder.clearToTokenAssociatedAddress()
+    }
+    /**
+     * `optional string to_token_associated_address = 4 [json_name = "toTokenAssociatedAddress"];`
+     * @return Whether the toTokenAssociatedAddress field is set.
+     */
+    public fun hasToTokenAssociatedAddress(): kotlin.Boolean {
+      return _builder.hasToTokenAssociatedAddress()
     }
   }
 }

--- a/kotlin/src/main/kotlin/vultisig/keysign/v1/SolanaSpecificKt.kt
+++ b/kotlin/src/main/kotlin/vultisig/keysign/v1/SolanaSpecificKt.kt
@@ -61,6 +61,40 @@ public object SolanaSpecificKt {
     public fun clearPriorityFee() {
       _builder.clearPriorityFee()
     }
+
+    /**
+     * `string from_token_associated_address = 3 [json_name = "fromTokenAssociatedAddress"];`
+     */
+    public var fromTokenAssociatedAddress: kotlin.String
+      @JvmName("getFromTokenAssociatedAddress")
+      get() = _builder.getFromTokenAssociatedAddress()
+      @JvmName("setFromTokenAssociatedAddress")
+      set(value) {
+        _builder.setFromTokenAssociatedAddress(value)
+      }
+    /**
+     * `string from_token_associated_address = 3 [json_name = "fromTokenAssociatedAddress"];`
+     */
+    public fun clearFromTokenAssociatedAddress() {
+      _builder.clearFromTokenAssociatedAddress()
+    }
+
+    /**
+     * `string to_token_associated_address = 4 [json_name = "toTokenAssociatedAddress"];`
+     */
+    public var toTokenAssociatedAddress: kotlin.String
+      @JvmName("getToTokenAssociatedAddress")
+      get() = _builder.getToTokenAssociatedAddress()
+      @JvmName("setToTokenAssociatedAddress")
+      set(value) {
+        _builder.setToTokenAssociatedAddress(value)
+      }
+    /**
+     * `string to_token_associated_address = 4 [json_name = "toTokenAssociatedAddress"];`
+     */
+    public fun clearToTokenAssociatedAddress() {
+      _builder.clearToTokenAssociatedAddress()
+    }
   }
 }
 @kotlin.jvm.JvmSynthetic

--- a/proto/vultisig/keysign/v1/blockchain_specific.proto
+++ b/proto/vultisig/keysign/v1/blockchain_specific.proto
@@ -36,6 +36,8 @@ message CosmosSpecific {
 message SolanaSpecific {
   string recent_block_hash = 1;
   string priority_fee = 2;
+  string from_token_associated_address = 3;
+  string to_token_associated_address = 4;
 }
 
 message PolkadotSpecific {

--- a/proto/vultisig/keysign/v1/blockchain_specific.proto
+++ b/proto/vultisig/keysign/v1/blockchain_specific.proto
@@ -36,8 +36,8 @@ message CosmosSpecific {
 message SolanaSpecific {
   string recent_block_hash = 1;
   string priority_fee = 2;
-  string from_token_associated_address = 3;
-  string to_token_associated_address = 4;
+  optional string from_token_associated_address = 3;
+  optional string to_token_associated_address = 4;
 }
 
 message PolkadotSpecific {


### PR DESCRIPTION
Solana sends coins not to a wallet directly, so we must create or get the address association between a token and a wallet for both the sender and the receiver.