### PR TITLE
Add repo standards (CLAUDE.md, safety hooks, templates)

### DIFF
--- a/.claude/hooks/block-dangerous.sh
+++ b/.claude/hooks/block-dangerous.sh
@@ -37,9 +37,8 @@ fi
 
 # ── Destructive git operations ─────────────────────────────────────────────
 DESTRUCTIVE_PATTERNS=(
-  "git push.*--force"
+  "git push.*--force[^-]"
   "git push.*-f "
-  "--force-with-lease"
   "--no-verify"
   "git reset --hard"
   "git checkout \."
@@ -67,7 +66,7 @@ SECRET_PATTERNS=(
   "\.key$"
   "\.p12$"
   "\.pfx$"
-  "keystore"
+  "\.keystore$"
   "\.jks$"
 )
 

--- a/.claude/hooks/block-dangerous.sh
+++ b/.claude/hooks/block-dangerous.sh
@@ -78,4 +78,11 @@ for pattern in "${SECRET_PATTERNS[@]}"; do
   fi
 done
 
+# ── Environment variable exposure ─────────────────────────────────
+if echo "$INPUT" | grep -qiE "\b(printenv|export -p)\b|echo.*(TOKEN|API_KEY|SECRET|PASSWORD|CREDENTIAL)|env\s*$|env\s*\|"; then
+  echo "BLOCKED: Environment variable exposure detected."
+  echo "Agents must not read or print secrets from the environment."
+  exit 2
+fi
+
 exit 0

--- a/.claude/hooks/block-dangerous.sh
+++ b/.claude/hooks/block-dangerous.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# PreToolUse hook: Block dangerous operations in Vultisig repos.
+
+INPUT="${1:-}"
+
+# ── Mainnet RPC endpoints ──────────────────────────────────────────────────
+MAINNET_PATTERNS=(
+  "mainnet.infura.io"
+  "eth-mainnet.g.alchemy.com"
+  "rpc.ankr.com/eth"
+  "api.etherscan.io"
+  "thornode.ninerealms.com"
+  "rpc.cosmos.network"
+  "api.solana.com"
+  "mainnet-beta"
+)
+
+for pattern in "${MAINNET_PATTERNS[@]}"; do
+  if echo "$INPUT" | grep -qi "$pattern"; then
+    echo "BLOCKED: Mainnet interaction detected (${pattern})."
+    echo "Agents must not interact with mainnet RPCs or contracts."
+    exit 2
+  fi
+done
+
+# ── Direct push to protected branches ─────────────────────────────────────
+if echo "$INPUT" | grep -qiE "git push.*(origin|upstream)?\s*(main|master)\b"; then
+  echo "BLOCKED: Direct push to main/master. Agents must work on branches and open PRs."
+  exit 2
+fi
+
+# ── PR merge (agents must never merge) ────────────────────────────────────
+if echo "$INPUT" | grep -qiE "gh pr merge|git merge (main|master)"; then
+  echo "BLOCKED: Agents must not merge PRs. Label 'agent:review' and let a human merge."
+  exit 2
+fi
+
+# ── Destructive git operations ─────────────────────────────────────────────
+DESTRUCTIVE_PATTERNS=(
+  "git push.*--force"
+  "git push.*-f "
+  "--force-with-lease"
+  "--no-verify"
+  "git reset --hard"
+  "git checkout \."
+  "git checkout -- \."
+  "git clean -f"
+  "git clean -fd"
+  "git branch -D"
+  "rm -rf"
+)
+
+for pattern in "${DESTRUCTIVE_PATTERNS[@]}"; do
+  if echo "$INPUT" | grep -qiE "$pattern"; then
+    echo "BLOCKED: Destructive operation detected (${pattern})."
+    exit 2
+  fi
+done
+
+# ── Secret/credential file edits ──────────────────────────────────────────
+SECRET_PATTERNS=(
+  "\.env$"
+  "\.env\."
+  "/secret"
+  "/credential"
+  "\.pem$"
+  "\.key$"
+  "\.p12$"
+  "\.pfx$"
+  "keystore"
+  "\.jks$"
+)
+
+for pattern in "${SECRET_PATTERNS[@]}"; do
+  if echo "$INPUT" | grep -qiE "$pattern"; then
+    echo "BLOCKED: Edit to sensitive file matching '${pattern}'."
+    echo "Agents must not modify secret/credential files."
+    exit 2
+  fi
+done
+
+exit 0

--- a/.claude/hooks/block-dangerous.sh
+++ b/.claude/hooks/block-dangerous.sh
@@ -62,11 +62,13 @@ SECRET_PATTERNS=(
   "\.env\."
   "/secret"
   "/credential"
+  "credentials\."
+  "secret\."
+  "keystore"
   "\.pem$"
   "\.key$"
   "\.p12$"
   "\.pfx$"
-  "\.keystore$"
   "\.jks$"
 )
 

--- a/.claude/hooks/block-dangerous.sh
+++ b/.claude/hooks/block-dangerous.sh
@@ -37,12 +37,12 @@ fi
 
 # ── Destructive git operations ─────────────────────────────────────────────
 DESTRUCTIVE_PATTERNS=(
-  "git push.*--force[^-]"
-  "git push.*-f "
+  "git push.*--force([^-]|$)"
+  "git push.*-f( |$)"
   "--no-verify"
   "git reset --hard"
-  "git checkout \."
-  "git checkout -- \."
+  "git checkout \\./?$"
+  "git checkout -- \\./?$"
   "git clean -f"
   "git clean -fd"
   "git branch -D"

--- a/.claude/hooks/on-failure-notify.sh
+++ b/.claude/hooks/on-failure-notify.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# PostToolUseFailure hook: surface build failure context for self-correction
+
+INPUT=$(cat)
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
+ERROR=$(echo "$INPUT" | jq -r '.error // empty' | head -5)
+
+if [ "$TOOL" = "Bash" ]; then
+  CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+  if echo "$CMD" | grep -qE '(go (build|vet|test)|make|protoc)'; then
+    echo "Build failure detected. Command: $CMD" >&2
+    echo "Error: $ERROR" >&2
+  fi
+fi
+
+exit 0

--- a/.claude/hooks/on-failure-notify.sh
+++ b/.claude/hooks/on-failure-notify.sh
@@ -7,7 +7,7 @@ ERROR=$(echo "$INPUT" | jq -r '.error // empty' | head -5)
 
 if [ "$TOOL" = "Bash" ]; then
   CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
-  if echo "$CMD" | grep -qE '(go (build|vet|test)|make|protoc)'; then
+  if echo "$CMD" | grep -qE '(go (build|vet|test)|make|protoc|buf( (format|lint|build|generate))?|\.\/build\.sh)'; then
     echo "Build failure detected. Command: $CMD" >&2
     echo "Error: $ERROR" >&2
   fi

--- a/.claude/hooks/quality-gate.sh
+++ b/.claude/hooks/quality-gate.sh
@@ -4,7 +4,12 @@
 
 cd "$CLAUDE_PROJECT_DIR" || exit 0
 
-MODIFIED=$(git diff --name-only --diff-filter=ACMR HEAD 2>/dev/null | grep -E '\.(go|proto)$' || true)
+MODIFIED=$(
+  {
+    git diff --name-only --diff-filter=ACMR HEAD
+    git ls-files --others --exclude-standard
+  } 2>/dev/null | grep -E '\.(go|proto)$' || true
+)
 
 if [ -z "$MODIFIED" ]; then
   exit 0

--- a/.claude/hooks/quality-gate.sh
+++ b/.claude/hooks/quality-gate.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# TaskCompleted hook: verify build passes before task completion
+# Exit 2 to block, exit 0 to allow
+
+cd "$CLAUDE_PROJECT_DIR" || exit 0
+
+MODIFIED=$(git diff --name-only --diff-filter=ACMR HEAD 2>/dev/null | grep -E '\.(go|proto)$' || true)
+
+if [ -z "$MODIFIED" ]; then
+  exit 0
+fi
+
+if [ -f Makefile ] && ! make build 2>&1; then
+  echo "Quality gate: build failed" >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,6 +27,24 @@
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-dangerous.sh\" \"$TOOL_INPUT\""
           }
         ]
+      },
+      {
+        "matcher": "MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-dangerous.sh\" \"$TOOL_INPUT\""
+          }
+        ]
+      },
+      {
+        "matcher": "NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-dangerous.sh\" \"$TOOL_INPUT\""
+          }
+        ]
       }
     ],
     "PostToolUseFailure": [

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -28,6 +28,28 @@
           }
         ]
       }
+    ],
+    "PostToolUseFailure": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/on-failure-notify.sh\""
+          }
+        ]
+      }
+    ],
+    "TaskCompleted": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/quality-gate.sh\""
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,33 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-dangerous.sh\" \"$TOOL_INPUT\""
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-dangerous.sh\" \"$TOOL_INPUT\""
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/block-dangerous.sh\" \"$TOOL_INPUT\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,36 @@
+# CodeRabbit configuration for Vultisig repos
+# Docs: https://docs.coderabbit.ai/guides/configure-coderabbit
+
+language: en
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  review_status: true
+  collapse_walkthrough: true
+  auto_review:
+    enabled: true
+    drafts: true
+    base_branches:
+      - main
+      - master
+  path_instructions:
+    - path: "**/*.proto"
+      instructions: |
+        Review Guidelines:
+        - Proto3 syntax, package vultisig.v1
+        - Field naming: snake_case, enums: UPPER_SNAKE_CASE with 0 = UNSPECIFIED
+        - Never remove fields — deprecate instead (breaking change affects all platforms)
+        - Every change requires buf generate to update Swift + Go code
+    - path: "Sources/swift/**,go/vultisig/**"
+      instructions: |
+        These are GENERATED files from buf generate. Do not review for style or suggest manual edits.
+        Only verify they match the proto definitions.
+  tools:
+    markdownlint:
+      enabled: true
+    github-checks:
+      enabled: true
+      timeout_ms: 300000
+chat:
+  auto_reply: true

--- a/.github/ISSUE_GUIDE.md
+++ b/.github/ISSUE_GUIDE.md
@@ -1,0 +1,95 @@
+# Issue Writing Guide
+
+_How to fill the Vultisig issue template so agents AND humans produce great results._
+
+---
+
+## Quick Start
+
+1. Pick a template (Bug Report or Feature Request)
+2. Fill frontmatter (metadata)
+3. Fill body (spec)
+4. Run the checklist at the bottom
+5. Submit
+
+**Time to fill:** 5-10 minutes for a well-scoped issue. If it takes longer, your scope is too big — split it.
+
+---
+
+## Frontmatter Reference
+
+| Field | Required | Values | Notes |
+|-------|----------|--------|-------|
+| `type` | Yes | `feature` `bugfix` `refactor` `chore` | Pick one. If it's both a fix and feature, split into two issues |
+| `priority` | Yes | `critical` `high` `medium` `low` | Critical = blocks release. High = this sprint. Medium = next sprint. Low = backlog |
+| `size` | Yes | `tiny` `small` `medium` | **No "large".** If it's large, decompose into smaller issues |
+| `platform` | Yes | `ios` `android` `web` `desktop` `sdk` `server` `docs` | Can be multiple |
+| `files.read` | Yes | File paths | Files the implementer needs to read for context |
+| `files.write` | Yes | File paths | Files to create or modify. Be specific |
+| `verify` | Yes | Shell commands | Commands that prove the work is done |
+
+### Size Guide
+
+| Size | Files Changed | Lines of Code | Example |
+|------|--------------|---------------|---------|
+| **tiny** | 1 file | <50 lines | Fix a typo, update a constant |
+| **small** | 1-3 files | 50-200 lines | Add a function, new component, fix a bug |
+| **medium** | 3-8 files | 200-500 lines | New feature with tests, refactor a module |
+| **large** | 8+ files | 500+ lines | **SPLIT THIS.** Agent will run out of context |
+
+---
+
+## Body Sections
+
+### Title: `[VERB] [WHAT] [WHERE]`
+
+Start with an action verb. Be specific about location.
+
+| Good | Bad |
+|------|-----|
+| Add new chain enum to vultisig.v1 | Add chain |
+| Fix deprecated field in KeygenMessage | Fix proto |
+
+### Problem (WHY)
+
+2-3 sentences: What's broken? Who's affected? What happens if we don't fix this?
+
+### Solution (WHAT, not HOW)
+
+1 paragraph describing the approach. Focus on the decision, not implementation details.
+
+### Scope: Must Do
+
+Specific, numbered deliverables. Each one should be independently checkable.
+
+### Scope: Must NOT Do
+
+**This section prevents 50% of agent failures.** Always include at least 2 anti-goals:
+- "Don't edit generated code in Sources/swift/ or go/vultisig/ manually"
+- "Don't remove existing proto fields — deprecate instead"
+- "Don't change the public API surface"
+
+### Acceptance Criteria
+
+Every criterion must be verifiable by running a command or checking a file.
+
+| Verifiable | Vague |
+|------------|-------|
+| `buf lint && buf build` succeeds | Proto is valid |
+| `buf generate` produces clean output | Code generates |
+
+### Examples
+
+Show input/output pairs or before/after. A single concrete example is worth 10 sentences.
+
+---
+
+## Pre-Submit Checklist
+
+- [ ] Title starts with a verb
+- [ ] Size is tiny/small/medium (never large)
+- [ ] files.read has at least 1 path
+- [ ] files.write has at least 1 path
+- [ ] At least 2 anti-goals in Must NOT Do
+- [ ] Every acceptance criterion is command-runnable
+- [ ] verify has at least 1 command

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,16 +4,17 @@ about: Report a bug for agent or human resolution
 labels: bug
 ---
 
----
+<!-- Fill in the AGENT block: priority = critical|high|medium|low, size = tiny|small|medium -->
+<!-- AGENT
 type: "bugfix"
-priority: ""              # critical | high | medium | low
-size: ""                  # tiny (<1 file) | small (1-3 files) | medium (3-8 files)
-platform: []              # ios | android | web | desktop | sdk | server | docs
+priority: ""
+size: ""
+platform: [all]
 files:
-  read: []                # Files for context
-  write: []               # Files to modify
-verify: []                # Commands to confirm fix
----
+  read: []
+  write: []
+verify: ["buf lint && buf build"]
+-->
 
 # [Fix] [WHAT] [WHERE]
 
@@ -52,9 +53,9 @@ verify: []                # Commands to confirm fix
 ## Examples
 
 **Before:**
-```
+```text
 ```
 
 **After:**
-```
+```text
 ```

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,60 @@
+---
+name: Bug Report
+about: Report a bug for agent or human resolution
+labels: bug
+---
+
+---
+type: "bugfix"
+priority: ""              # critical | high | medium | low
+size: ""                  # tiny (<1 file) | small (1-3 files) | medium (3-8 files)
+platform: []              # ios | android | web | desktop | sdk | server | docs
+files:
+  read: []                # Files for context
+  write: []               # Files to modify
+verify: []                # Commands to confirm fix
+---
+
+# [Fix] [WHAT] [WHERE]
+
+## Problem
+<!-- 2-3 sentences. What's broken? Who's affected? -->
+
+
+## Expected Behavior
+<!-- What should happen instead? -->
+
+
+## Steps to Reproduce
+1.
+2.
+3.
+
+## Solution
+<!-- 1 paragraph. WHAT to do and WHY this approach. Not implementation details. -->
+
+
+## Scope
+
+### Must Do
+- [ ] <!-- Specific fix 1 -->
+- [ ] <!-- Specific fix 2 -->
+
+### Must NOT Do
+- <!-- Don't refactor unrelated code -->
+- <!-- Don't change public API surface -->
+
+## Acceptance Criteria
+- [ ] `buf lint && buf build` succeeds
+- [ ] `buf generate` produces clean output
+- [ ] <!-- Specific behavior check -->
+
+## Examples
+
+**Before:**
+```
+```
+
+**After:**
+```
+```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,16 +4,17 @@ about: Request a new feature for agent or human implementation
 labels: enhancement
 ---
 
----
+<!-- Fill in the AGENT block: priority = critical|high|medium|low, size = tiny|small|medium -->
+<!-- AGENT
 type: "feature"
-priority: ""              # critical | high | medium | low
-size: ""                  # tiny (<1 file) | small (1-3 files) | medium (3-8 files)
-platform: []              # ios | android | web | desktop | sdk | server | docs
+priority: ""
+size: ""
+platform: [all]
 files:
-  read: []                # Files for context
-  write: []               # Files to create or modify
-verify: []                # Commands to confirm completion
----
+  read: []
+  write: []
+verify: ["buf lint && buf build"]
+-->
 
 # [Add/Implement] [WHAT] [WHERE]
 
@@ -48,11 +49,11 @@ verify: []                # Commands to confirm completion
 ## Examples
 
 **Input:**
-```
+```text
 ```
 
 **Output:**
-```
+```text
 ```
 
 ## Technical Notes

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,59 @@
+---
+name: Feature Request
+about: Request a new feature for agent or human implementation
+labels: enhancement
+---
+
+---
+type: "feature"
+priority: ""              # critical | high | medium | low
+size: ""                  # tiny (<1 file) | small (1-3 files) | medium (3-8 files)
+platform: []              # ios | android | web | desktop | sdk | server | docs
+files:
+  read: []                # Files for context
+  write: []               # Files to create or modify
+verify: []                # Commands to confirm completion
+---
+
+# [Add/Implement] [WHAT] [WHERE]
+
+## Problem
+<!-- 2-3 sentences. What's missing or suboptimal? -->
+
+
+## Solution
+<!-- 1 paragraph. WHAT to do and WHY this approach. -->
+
+
+## Scope
+
+### Must Do
+- [ ] <!-- Specific deliverable 1 -->
+- [ ] <!-- Specific deliverable 2 -->
+- [ ] <!-- Specific deliverable 3 -->
+
+### Must NOT Do
+- <!-- Don't change existing behavior -->
+- <!-- Don't add extra dependencies without approval -->
+
+### Out of Scope
+- <!-- Related but separate work → future issue -->
+
+## Acceptance Criteria
+- [ ] `buf lint && buf build` succeeds
+- [ ] `buf generate` produces clean output
+- [ ] <!-- Specific behavior check 1 -->
+- [ ] <!-- Specific behavior check 2 -->
+
+## Examples
+
+**Input:**
+```
+```
+
+**Output:**
+```
+```
+
+## Technical Notes
+<!-- Architecture decisions, gotchas, related code patterns. Optional. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Description
+
+Fixes #{issue-number}
+
+<!-- Brief description of what changed and why -->
+
+## Type
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Refactor
+- [ ] Docs
+- [ ] Test
+
+## Agent Metadata
+
+<!-- Auto-filled by agent. Leave blank for human PRs. -->
+- Agent: <!-- agent name -->
+- Issue: <!-- #number -->
+- Rounds: <!-- feedback rounds addressed -->
+
+## Checklist
+
+- [ ] Tests pass locally
+- [ ] Lint clean
+- [ ] CodeRabbit feedback addressed
+- [ ] Self-review done
+- [ ] No secrets committed
+- [ ] Conventional commit messages used

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# commondata — Agent Reference
+
+## Overview
+
+Shared protobuf schemas defining the data contract between all Vultisig apps. Changes here affect iOS, Android, Windows, and all Go services.
+
+## Quick Start
+
+```bash
+git clone https://github.com/vultisig/commondata.git
+cd commondata
+make                    # runs buf via Docker (no local buf needed)
+# Or locally: ./build.sh (requires buf CLI)
+```
+
+## Before You Change Code
+
+1. This is a submodule used by iOS, Android, and Go services — changes ripple everywhere
+2. Run `make` (or `./build.sh`) to validate current state
+3. Only edit files in `proto/vultisig/` — never touch `Sources/swift/` or `go/vultisig/` (generated)
+4. After proto changes: run `buf generate` and commit generated code alongside proto changes
+5. Breaking changes affect ALL platforms — deprecate fields, never remove them
+
+## Patterns
+
+- Proto3 syntax, package `vultisig.v1`
+- Generated code: Sources/swift/ (Swift), go/vultisig/ (Go) — never edit generated files
+- Token metadata in tokens/ directory
+- buf.yaml for linting rules, buf.gen.yaml for code generation
+
+## Security Notes
+
+- Proto field removal is a breaking change — deprecate instead
+- Generated code must be committed alongside proto changes
+- Token metadata affects balance display — validate carefully

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,3 +33,13 @@ make                    # runs buf via Docker (no local buf needed)
 - Proto field removal is a breaking change — deprecate instead
 - Generated code must be committed alongside proto changes
 - Token metadata affects balance display — validate carefully
+
+## Knowledge Base
+
+For deeper context beyond this file, see [vultisig-knowledge](https://github.com/vultisig/vultisig-knowledge).
+
+Key docs for this repo:
+- [repos/commondata.md](https://github.com/vultisig/vultisig-knowledge/blob/main/repos/commondata.md)
+- [repos/index.md](https://github.com/vultisig/vultisig-knowledge/blob/main/repos/index.md) (dependency graph)
+- [coding/gotchas.md](https://github.com/vultisig/vultisig-knowledge/blob/main/coding/gotchas.md) (see "commondata changes break everything")
+- [coding/dependencies.md](https://github.com/vultisig/vultisig-knowledge/blob/main/coding/dependencies.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ Update workflow:
 - Field naming: snake_case
 - Enums: UPPER_SNAKE_CASE with 0 = UNSPECIFIED
 - Every field change needs backwards compatibility consideration
+- Comments on all message types, enums, services, and non-obvious fields
 
 ## Dependencies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ buf generate
 
 Protobuf schema repository with code generation.
 
-```
+```text
 proto/vultisig/         → .proto definitions (SOURCE OF TRUTH)
 Sources/swift/vultisig/ → Generated Swift code (do not edit)
 go/vultisig/            → Generated Go code (do not edit)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# commondata
+
+Shared protobuf schemas for cross-platform communication. Source of truth for data contracts between all Vultisig apps.
+
+## Security Tier
+
+HIGH
+
+## Critical Boundaries
+
+- `proto/vultisig/` — Source of truth. Any change here requires regeneration on ALL platforms.
+- `Sources/swift/` and `go/vultisig/` — Generated code. Do NOT edit manually.
+- Breaking proto changes affect iOS, Android, Windows, and all Go services.
+
+## Key Commands
+
+```bash
+# Full workflow via Docker (no local buf needed)
+make                    # runs buf format, lint, build, generate in Docker
+
+# Or locally if buf is installed:
+buf format --write
+buf lint && buf build
+buf generate
+
+# Or use the build script directly:
+./build.sh              # format + lint + build + generate
+```
+
+## Architecture
+
+Protobuf schema repository with code generation.
+
+```
+proto/vultisig/         → .proto definitions (SOURCE OF TRUTH)
+Sources/swift/vultisig/ → Generated Swift code (do not edit)
+go/vultisig/            → Generated Go code (do not edit)
+tokens/                 → Token metadata
+buf.yaml                → Buf configuration
+buf.gen.yaml            → Code generation config
+buf.lock                → Buf dependency lock
+Package.swift           → Swift package manifest
+Package.resolved        → Swift package resolution
+go.mod                  → Go module definition
+Makefile                → Docker-based buf workflow
+build.sh                → buf format + lint + build + generate
+```
+
+Update workflow:
+1. Edit `.proto` files in `proto/vultisig/`
+2. Run `buf format --write && buf lint && buf build`
+3. Run `buf generate`
+4. Commit generated code alongside proto changes
+5. Update submodule refs in iOS, Android repos
+
+## Code Conventions
+
+- Proto3 syntax
+- Package: `vultisig.v1`
+- Field naming: snake_case
+- Enums: UPPER_SNAKE_CASE with 0 = UNSPECIFIED
+- Every field change needs backwards compatibility consideration
+
+## Dependencies
+
+- **buf** — Protobuf tooling (required for all operations)
+- Used as git submodule in: vultisig-ios, vultisig-android

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,3 +65,14 @@ Update workflow:
 
 - **buf** — Protobuf tooling (required for all operations)
 - Used as git submodule in: vultisig-ios, vultisig-android
+
+## Knowledge Base
+
+For deeper context, see [vultisig-knowledge](https://github.com/vultisig/vultisig-knowledge). Read only when needed:
+
+| Situation | Read |
+|-----------|------|
+| First time in this repo | [repos/commondata.md](https://github.com/vultisig/vultisig-knowledge/blob/main/repos/commondata.md) |
+| Understanding cross-repo impact | [coding/gotchas.md](https://github.com/vultisig/vultisig-knowledge/blob/main/coding/gotchas.md) (see "commondata changes break everything") |
+| Which repos depend on this | [repos/index.md](https://github.com/vultisig/vultisig-knowledge/blob/main/repos/index.md) (dependency graph) |
+| Checking dependency versions | [coding/dependencies.md](https://github.com/vultisig/vultisig-knowledge/blob/main/coding/dependencies.md) |


### PR DESCRIPTION
## Summary

- **CLAUDE.md** — Build commands (make, build.sh, buf), architecture map, proto conventions. For humans with Claude Code and autonomous agents.
- **AGENTS.md** — Quick start, patterns, security notes. Agent-focused reference.
- **.claude/settings.json + hooks/block-dangerous.sh** — PreToolUse safety hooks that block mainnet RPCs, destructive git, secret file edits, force push, and direct push to main.
- **.github/** — PR template, issue templates (bug + feature) with agent-friendly frontmatter, issue writing guide.
- **.coderabbit.yaml** — CodeRabbit review config (chill profile, proto review rules, generated code flagged as read-only).

## Why

These files enable the Vultisig developer agent framework. They give both human devs (using Claude Code) and autonomous agents the context they need to work safely in this repo. Safety hooks provide defense-in-depth alongside branch protection.

## What to review

- **CLAUDE.md** — Does the architecture map match reality? Are buf commands correct?
- **AGENTS.md** — Anything missing for someone new to this repo?
- **.coderabbit.yaml** — Proto review rules and generated-code handling match your preferences?
- **Issue templates** — Frontmatter fields useful? Acceptance criteria defaults correct?

The safety hooks and PR template are standardized across all Vultisig repos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive issue-writing guide, bug and feature request templates, and a standardized pull-request template
  * Added agent/protobuf workflow and repo onboarding docs

* **Chores**
  * Added repository safety hooks to block risky operations and to notify on failures
  * Added a task-completion quality gate to enforce successful builds
  * Added code-review configuration and auto-review tooling settings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->