### PR TITLE
feat(tokens): rebrand TON native token to GRAM

### DIFF
--- a/tokens/tokens.json
+++ b/tokens/tokens.json
@@ -1398,8 +1398,8 @@
   ],
   "ton": [
     {
-      "ticker": "TON",
-      "logo": "ton",
+      "ticker": "GRAM",
+      "logo": "gram",
       "price_provider_id": "the-open-network",
       "is_native_token": true,
       "decimals": 9


### PR DESCRIPTION
## What

Rebrands the native token of The Open Network from **Toncoin (TON)** to **Gram (GRAM)** in `tokens/tokens.json`.

```diff
   "ton": [
     {
-      "ticker": "TON",
-      "logo": "ton",
+      "ticker": "GRAM",
+      "logo": "gram",
       "price_provider_id": "the-open-network",
       "is_native_token": true,
       "decimals": 9
```

## Why

The Open Network community voted (81.22% in favor) to rename the native token to Gram, effective 2026-06-15. This is a cosmetic **token** rebrand (name/ticker/logo) — the blockchain stays "The Open Network" and there is no swap/bridge/claim/migration. Addresses, balances, contracts, NFTs, and staking are unchanged.

## Deliberately unchanged (protocol/identity keys)

- Chain key `"ton"` — serialization/identity shared cross-platform
- `price_provider_id: "the-open-network"` — kept until CoinGecko renames its id (changing early breaks price lookups)
- `decimals: 9`, `is_native_token: true`

## Cross-platform follow-up

`logo: "gram"` is a name string each platform resolves to its own bundled asset. Every consumer (vultisig-windows/extension, iOS, Android, SDK) must add a `gram` **coin** logo asset while keeping the existing **TON chain** logo (network identity is unchanged).

Closes #91. Refs vultisig-windows#4129, vultisig-android#4981, vultisig-ios#4617.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
