### PR TITLE
docs(keysign): clarify XRP destination tag transition

### DIFF
--- a/Sources/swift/vultisig/keysign/v1/blockchain_specific.pb.swift
+++ b/Sources/swift/vultisig/keysign/v1/blockchain_specific.pb.swift
@@ -417,11 +417,12 @@ public struct VSRippleSpecific {
 
   /// XRPL DestinationTag: 32-bit unsigned integer, optional (proto3 `optional`
   /// so a present tag of 0 is distinguishable from "no tag"). During the
-  /// dual-write transition the tag is ALSO carried in the generic
+  /// dual-write transition, tag-only sends ALSO carry the tag in the generic
   /// KeysignPayload.memo as a canonical uint32 decimal; signers prefer this
   /// field and fall back to the memo so mixed-version device pairs stay
-  /// byte-identical in MPC keysign. The memo carrier is retired once every
-  /// platform reads this field.
+  /// byte-identical in MPC keysign. A tag combined with an independent memo
+  /// requires every signer to understand this field. The memo carrier is
+  /// retired once every platform reads this field.
   public var destinationTag: UInt32 {
     get {return _destinationTag ?? 0}
     set {_destinationTag = newValue}

--- a/go/vultisig/keysign/v1/blockchain_specific.pb.go
+++ b/go/vultisig/keysign/v1/blockchain_specific.pb.go
@@ -1084,11 +1084,12 @@ type RippleSpecific struct {
 	LastLedgerSequence uint64 `protobuf:"varint,3,opt,name=last_ledger_sequence,json=lastLedgerSequence,proto3" json:"last_ledger_sequence,omitempty"`
 	// XRPL DestinationTag: 32-bit unsigned integer, optional (proto3 `optional`
 	// so a present tag of 0 is distinguishable from "no tag"). During the
-	// dual-write transition the tag is ALSO carried in the generic
+	// dual-write transition, tag-only sends ALSO carry the tag in the generic
 	// KeysignPayload.memo as a canonical uint32 decimal; signers prefer this
 	// field and fall back to the memo so mixed-version device pairs stay
-	// byte-identical in MPC keysign. The memo carrier is retired once every
-	// platform reads this field.
+	// byte-identical in MPC keysign. A tag combined with an independent memo
+	// requires every signer to understand this field. The memo carrier is
+	// retired once every platform reads this field.
 	DestinationTag *uint32 `protobuf:"varint,4,opt,name=destination_tag,json=destinationTag,proto3,oneof" json:"destination_tag,omitempty"`
 }
 

--- a/proto/vultisig/keysign/v1/blockchain_specific.proto
+++ b/proto/vultisig/keysign/v1/blockchain_specific.proto
@@ -127,11 +127,12 @@ message RippleSpecific {
   uint64 last_ledger_sequence = 3;
   // XRPL DestinationTag: 32-bit unsigned integer, optional (proto3 `optional`
   // so a present tag of 0 is distinguishable from "no tag"). During the
-  // dual-write transition the tag is ALSO carried in the generic
+  // dual-write transition, tag-only sends ALSO carry the tag in the generic
   // KeysignPayload.memo as a canonical uint32 decimal; signers prefer this
   // field and fall back to the memo so mixed-version device pairs stay
-  // byte-identical in MPC keysign. The memo carrier is retired once every
-  // platform reads this field.
+  // byte-identical in MPC keysign. A tag combined with an independent memo
+  // requires every signer to understand this field. The memo carrier is
+  // retired once every platform reads this field.
   optional uint32 destination_tag = 4;
 }
 


### PR DESCRIPTION
Clarifies the generated RippleSpecific.destination_tag contract: tag-only sends use the legacy memo carrier for mixed-version compatibility, while a destination tag combined with an independent memo requires every signer to understand the first-class field. Regenerates the Swift and Go bindings without changing the wire schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified and reworded documentation for XRPL destination tag behavior during the dual-write transition.
  * Improved explanation of memo and tag fallback semantics.
  * No functional or data structure changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->